### PR TITLE
Fix login, DNI instead email#38

### DIFF
--- a/app/Annotations/OpenApi/controllersAnnotations/authAnnotations/AnnotationsAuth.php
+++ b/app/Annotations/OpenApi/controllersAnnotations/authAnnotations/AnnotationsAuth.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace App\Annotations\OpenApi\controllersAnnotations\loginAnnotations;
+namespace App\Annotations\OpenApi\controllersAnnotations\authAnnotations;
 
-class AnnotationsLogin
+class AnnotationsAuth
 {
     /**
      * @OA\Post(
@@ -17,7 +17,7 @@ class AnnotationsLogin
      *
      *          @OA\JsonContent(
      *
-     *              @OA\Property(property="email", type="string", format="email", example="john@example.com"),
+     *              @OA\Property(property="DNI/NIE", type="string", format="text", example="Z0038540C/83749707Z"),
      *              @OA\Property(property="password", type="string", format="password", example="secretpassword")
      *          )
      *      ),

--- a/app/Http/Controllers/api/AdminController.php
+++ b/app/Http/Controllers/api/AdminController.php
@@ -21,10 +21,16 @@ class AdminController extends Controller
         $admins = Admin::all();
 
         if ($admins->isEmpty()) {
-            throw new HttpResponseException(response()->json(['message' => __('No hi ha administradors a la base de dades')], 404));
+            throw new HttpResponseException(response()->json(
+                ['message' => __('No hi ha administradors a la base de dades')],
+                404
+            ));
         }
 
-        return response()->json(['data' => AdminIndexResource::collection($admins)], 200);
+        return response()->json(
+            ['data' => AdminIndexResource::collection($admins)],
+            200
+        );
     }
 
     public function store(UserRequest $request)
@@ -44,10 +50,16 @@ class AdminController extends Controller
             return $user;
         });
         if (!$transaction) {
-            throw new HttpResponseException(response()->json(['message' => __('Registre no efectuat. Si-us-plau, torna-ho a provar.')], 404));
+            throw new HttpResponseException(response()->json(
+                ['message' => __('Registre no efectuat. Si-us-plau, torna-ho a provar.')],
+                404
+            ));
         }
 
-        return response()->json(['message' => __('Registre realitzat amb èxit.')], 201);
+        return response()->json(
+            ['message' => __('Registre realitzat amb èxit.')],
+            201
+        );
     }
 
     public function show($id)
@@ -56,20 +68,27 @@ class AdminController extends Controller
         $admin = $this->findAdmin($id);
 
         if (!$admin) {
-            throw new HttpResponseException(response()->json(['message' => __('No hi ha administradors a la base de dades')], 404));
+            throw new HttpResponseException(response()->json(
+                ['message' => __('No hi ha administradors a la base de dades')],
+                404
+            ));
         }
         if ($admin->id !== $loggeuser->admin->id) {
-            return response()->json(['message' => __('No tens permisos per veure aquest usuari.')], 401);
+            return response()->json(
+                ['message' => __('No tens permisos per veure aquest usuari.')],
+                401
+            );
         }
 
-        return response()->json(['data' => new AdminShowResource($admin)], 200);
+        return response()->json(
+            ['data' => new AdminShowResource($admin)],
+            200
+        );
     }
 
     private function findAdmin($id)
     {
-        $admin = Admin::findOrFail($id);
-
-        return $admin;
+        return Admin::findOrFail($id);
     }
 
     public function update(Request $request, $id)
@@ -78,17 +97,23 @@ class AdminController extends Controller
 
         $admin = $this->findAdmin($id);
         if ($admin->id !== $loggeuser->admin->id) {
-            throw new HttpResponseException(response()->json(['message' => __('No tens permís per modificar aquest usuari')], 401));
+            throw new HttpResponseException(response()->json(
+                ['message' => __('No tens permís per modificar aquest usuari')],
+                401
+            ));
         }
 
         if (!$admin) {
-            throw new HttpResponseException(response()->json(['message' => __('No hi ha administradors a la base de dades')], 404));
+            throw new HttpResponseException(response()->json(
+                ['message' => __('No hi ha administradors a la base de dades')],
+                404
+            ));
         }
 
         if ($request->surname) {
             $admin->user->surname = $request->surname;
-
-        }if ($request->name) {
+        }
+        if ($request->name) {
             $admin->user->name = $request->name;
         }
         if ($request->email) {
@@ -96,8 +121,10 @@ class AdminController extends Controller
         }
         $admin->save();
 
-        return response()->json(['message' => 'Usuari actualitzat amb èxit', 'data' => new AdminshowResource($admin)], 200);
-
+        return response()->json(
+            ['message' => 'Usuari actualitzat amb èxit', 'data' => new AdminshowResource($admin)],
+            200
+        );
     }
 
     public function destroy($id)
@@ -107,10 +134,16 @@ class AdminController extends Controller
         $loggeuser = Auth::user();
         $id = $this->findAdmin($id);
         if ($admin->id !== $loggeuser->admin->id) {
-            throw new HttpResponseException(response()->json(['message' => __('No tens permís per eliminar aquest usuari')], 401));
+            throw new HttpResponseException(response()->json(
+                ['message' => __('No tens permís per eliminar aquest usuari')],
+                401
+            ));
         }
         $admin->user->delete();
 
-        return response()->json(['message' => __('La seva compte ha estat eliminada amb èxit')], 200);
+        return response()->json(
+            ['message' => __('La seva compte ha estat eliminada amb èxit')],
+            200
+        );
     }
 }

--- a/app/Http/Controllers/api/AuthController.php
+++ b/app/Http/Controllers/api/AuthController.php
@@ -15,7 +15,7 @@ class AuthController extends Controller
             $credentials = $request->only('dni', 'password');
 
             $user = $this->verifyUser($credentials);
-             /** @var \App\Models\User $user * */
+            /** @var \App\Models\User $user * */
             $token = $user->createToken('auth_token')->accessToken;
 
             return response()->json([
@@ -33,7 +33,7 @@ class AuthController extends Controller
     {
 
         if (!Auth::attempt($credentials)) {
-            throw new Exception(__('Credencials invàlides, comprova-les i torneu a iniciar sessió'),401);
+            throw new Exception(__('Credencials invàlides, comprova-les i torneu a iniciar sessió'), 401);
 
         }
         return Auth::user();
@@ -44,7 +44,7 @@ class AuthController extends Controller
     public function logout()
     {
         $user = Auth::user();
-         /** @var \App\Models\User $user * */
+        /** @var \App\Models\User $user * */
         $user->tokens()->delete();
 
         return response()->json(['message' => __('Desconnexió realitzada amb èxit')], 200);

--- a/app/Http/Controllers/api/AuthController.php
+++ b/app/Http/Controllers/api/AuthController.php
@@ -9,7 +9,7 @@ use Illuminate\Support\Facades\Auth;
 
 
 
-class LoginController extends Controller
+class AuthController extends Controller
 {
     public function login(LoginRequest $request) 
     {
@@ -33,7 +33,7 @@ class LoginController extends Controller
     private function verifyUser(array $credentials) {
 
         if (!Auth::attempt($credentials)) {
-            throw new Exception(('Credencials invàlides, comprova-les i torneu a iniciar sessió'));
+            throw new Exception(__('Credencials invàlides, comprova-les i torneu a iniciar sessió'));
            
         } 
         return Auth::user();

--- a/app/Http/Controllers/api/AuthController.php
+++ b/app/Http/Controllers/api/AuthController.php
@@ -15,6 +15,7 @@ class AuthController extends Controller
             $credentials = $request->only('dni', 'password');
 
             $user = $this->verifyUser($credentials);
+             /** @var \App\Models\User $user * */
             $token = $user->createToken('auth_token')->accessToken;
 
             return response()->json([
@@ -23,8 +24,8 @@ class AuthController extends Controller
                 'token' => $token
             ], 200);
 
-        } catch (Exception $ex) {
-            return response()->json(['message' => __($ex->getMessage())], 401);
+        } catch (Exception $validationException) {
+            return response()->json(['message' => __($validationException->getMessage())], $e);
         }
     }
 
@@ -32,7 +33,7 @@ class AuthController extends Controller
     {
 
         if (!Auth::attempt($credentials)) {
-            throw new Exception(__('Credencials invàlides, comprova-les i torneu a iniciar sessió'));
+            throw new Exception(__('Credencials invàlides, comprova-les i torneu a iniciar sessió'),401);
 
         }
         return Auth::user();
@@ -43,7 +44,7 @@ class AuthController extends Controller
     public function logout()
     {
         $user = Auth::user();
-
+         /** @var \App\Models\User $user * */
         $user->tokens()->delete();
 
         return response()->json(['message' => __('Desconnexió realitzada amb èxit')], 200);

--- a/app/Http/Controllers/api/AuthController.php
+++ b/app/Http/Controllers/api/AuthController.php
@@ -25,7 +25,8 @@ class AuthController extends Controller
             ], 200);
 
         } catch (Exception $validationException) {
-            return response()->json(['message' => __($validationException->getMessage())], $e);
+            return response()->json(['message' => __($validationException->getMessage())], $validationException->getCode()
+        );
         }
     }
 

--- a/app/Http/Controllers/api/AuthController.php
+++ b/app/Http/Controllers/api/AuthController.php
@@ -7,16 +7,14 @@ use App\Http\Requests\LoginRequest;
 use Exception;
 use Illuminate\Support\Facades\Auth;
 
-
-
 class AuthController extends Controller
 {
-    public function login(LoginRequest $request) 
+    public function login(LoginRequest $request)
     {
         try {
             $credentials = $request->only('dni', 'password');
 
-           $user= $this->verifyUser($credentials);
+            $user = $this->verifyUser($credentials);
             $token = $user->createToken('auth_token')->accessToken;
 
             return response()->json([
@@ -30,16 +28,17 @@ class AuthController extends Controller
         }
     }
 
-    private function verifyUser(array $credentials) {
+    private function verifyUser(array $credentials)
+    {
 
         if (!Auth::attempt($credentials)) {
             throw new Exception(__('Credencials invàlides, comprova-les i torneu a iniciar sessió'));
-           
-        } 
+
+        }
         return Auth::user();
     }
 
-   
+
 
     public function logout()
     {

--- a/app/Http/Controllers/api/AuthController.php
+++ b/app/Http/Controllers/api/AuthController.php
@@ -25,8 +25,10 @@ class AuthController extends Controller
             ], 200);
 
         } catch (Exception $validationException) {
-            return response()->json(['message' => __($validationException->getMessage())], $validationException->getCode()
-        );
+            return response()->json(
+                ['message' => __($validationException->getMessage())],
+                $validationException->getCode()
+            );
         }
     }
 

--- a/app/Http/Controllers/api/LoginController.php
+++ b/app/Http/Controllers/api/LoginController.php
@@ -13,7 +13,7 @@ class LoginController extends Controller
     {
 
         $data = [
-            'email' => $request->email,
+            'dni' => $request->dni,
             'password' => $request->password,
         ];
 
@@ -25,7 +25,7 @@ class LoginController extends Controller
             return response()->json(['message' => __('Autenticació amb èxit. Benvingut'), 'name' => $user->name, 'token' => $token], 200);
         }
 
-        throw new HttpResponseException(response()->json(['message' => __('Email o contrasenya incorrecte')], 401));
+        throw new HttpResponseException(response()->json(['message' => __('Dni-Nie o contrasenya incorrecte')], 401));
     }
 
     public function logout()

--- a/app/Http/Requests/LoginRequest.php
+++ b/app/Http/Requests/LoginRequest.php
@@ -2,7 +2,7 @@
 
 namespace App\Http\Requests;
 
-use App\Rules\DniRule;
+use App\Rules\DniNieRule;
 use Illuminate\Contracts\Validation\Validator;
 use Illuminate\Foundation\Http\FormRequest;
 use Illuminate\Http\Exceptions\HttpResponseException;
@@ -25,7 +25,7 @@ class LoginRequest extends FormRequest
     public function rules(): array
     {
         return [
-            'dni' => ['required','string', new DniRule()],
+            'dni' => ['required','string', new DniNieRule()],
             'password' => 'required|min:8|string',
         ];
     }

--- a/app/Http/Requests/LoginRequest.php
+++ b/app/Http/Requests/LoginRequest.php
@@ -2,10 +2,10 @@
 
 namespace App\Http\Requests;
 
+use App\Rules\DniRule;
 use Illuminate\Contracts\Validation\Validator;
 use Illuminate\Foundation\Http\FormRequest;
 use Illuminate\Http\Exceptions\HttpResponseException;
-use App\Rules\DniRule;
 
 class LoginRequest extends FormRequest
 {

--- a/app/Http/Requests/LoginRequest.php
+++ b/app/Http/Requests/LoginRequest.php
@@ -5,6 +5,7 @@ namespace App\Http\Requests;
 use Illuminate\Contracts\Validation\Validator;
 use Illuminate\Foundation\Http\FormRequest;
 use Illuminate\Http\Exceptions\HttpResponseException;
+use App\Rules\DniRule;
 
 class LoginRequest extends FormRequest
 {
@@ -24,7 +25,7 @@ class LoginRequest extends FormRequest
     public function rules(): array
     {
         return [
-            'email' => 'required',
+            'dni' => ['required', new DniRule()],
             'password' => 'required|min:8',
         ];
     }

--- a/app/Http/Requests/LoginRequest.php
+++ b/app/Http/Requests/LoginRequest.php
@@ -25,8 +25,8 @@ class LoginRequest extends FormRequest
     public function rules(): array
     {
         return [
-            'dni' => ['required', new DniRule()],
-            'password' => 'required|min:8',
+            'dni' => ['required','string', new DniRule()],
+            'password' => 'required|min:8|string',
         ];
     }
 

--- a/app/Http/Requests/UserRequest.php
+++ b/app/Http/Requests/UserRequest.php
@@ -2,7 +2,7 @@
 
 namespace App\Http\Requests;
 
-use App\Rules\DniRule;
+use App\Rules\DniNieRule;
 use Illuminate\Contracts\Validation\Validator;
 use Illuminate\Foundation\Http\FormRequest;
 use Illuminate\Http\Exceptions\HttpResponseException;
@@ -28,7 +28,7 @@ class UserRequest extends FormRequest
         return [
             'name' => ['required', 'string', 'regex:/^[^0-9\/?|\\)(*&%$#@!{}\[\]:;_="<>]+$/'],
             'surname' => ['required', 'string', 'regex:/^[^0-9\/?|\\)(*&%$#@!{}\[\]:;_="<>]+$/'],
-            'dni' => ['required', 'unique:users', new DniRule()],
+            'dni' => ['required', 'unique:users', new DniNieRule()],
             'email' => 'required|string|email|max:255|unique:users',
             'password' => 'required|string|min:8',
         ];

--- a/app/Rules/DniNieRule.php
+++ b/app/Rules/DniNieRule.php
@@ -5,7 +5,7 @@ namespace App\Rules;
 use Closure;
 use Illuminate\Contracts\Validation\ValidationRule;
 
-class DniRule implements ValidationRule
+class DniNieRule implements ValidationRule
 {
     /**
      * Run the validation rule.

--- a/routes/api/v1.php
+++ b/routes/api/v1.php
@@ -1,7 +1,7 @@
 <?php
 
 use App\Http\Controllers\api\AdminController;
-use App\Http\Controllers\api\LoginController;
+use App\Http\Controllers\api\AuthController;
 use App\Http\Controllers\api\StudentController;
 use Illuminate\Support\Facades\Route;
 
@@ -17,7 +17,7 @@ use Illuminate\Support\Facades\Route;
 */
 
 //No Auth
-Route::post('login', [LoginController::class, 'login'])->name('login');
+Route::post('login', [AuthController::class, 'login'])->name('login');
 Route::post('/students', [StudentController::class, 'store'])->name('student.create');
 Route::get('/students', [StudentController::class, 'index'])->name('students.list');
 Route::get('/students/{id}', [StudentController::class, 'show'])->name('student.show');
@@ -35,6 +35,6 @@ Route::middleware('auth:api')->group(function () {
     Route::delete('/admins/{id}', [AdminController::class, 'destroy'])->middleware('role:admin')->name('admin.destroy');
     Route::get('/admins', [AdminController::class, 'index'])->middleware('role:admin')->name('admin.index');
     //logout
-    Route::post('/logout', [LoginController::class, 'logout'])->name('logout');
+    Route::post('/logout', [AuthController::class, 'logout'])->name('logout');
 
 });

--- a/storage/api-docs/api-docs.json
+++ b/storage/api-docs/api-docs.json
@@ -923,10 +923,10 @@
                         "application/json": {
                             "schema": {
                                 "properties": {
-                                    "email": {
+                                    "DNI/NIE": {
                                         "type": "string",
-                                        "format": "email",
-                                        "example": "john@example.com"
+                                        "format": "text",
+                                        "example": "Z0038540C/83749707Z"
                                     },
                                     "password": {
                                         "type": "string",

--- a/tests/Feature/AuthControllerTest.php
+++ b/tests/Feature/AuthControllerTest.php
@@ -6,7 +6,7 @@ use App\Models\User;
 use Illuminate\Foundation\Testing\DatabaseTransactions;
 use Tests\TestCase;
 
-class LoginControllerTest extends TestCase
+class AuthControllerTest extends TestCase
 {
     use DatabaseTransactions;
 

--- a/tests/Feature/AuthControllerTest.php
+++ b/tests/Feature/AuthControllerTest.php
@@ -54,7 +54,7 @@ class AuthControllerTest extends TestCase
     {
         User::factory()->create();
 
-        $response =$this->postJson(route('login'));
+        $response = $this->postJson(route('login'));
         $response->assertStatus(422)
             ->assertJsonValidationErrors(['dni', 'password'])
             ->assertJson([
@@ -83,7 +83,7 @@ class AuthControllerTest extends TestCase
         $user = User::factory()->create();
         $this->actingAs($user, 'api');
 
-        $response =$this->postJson(route('logout'));
+        $response = $this->postJson(route('logout'));
 
         $response->assertStatus(200);
 

--- a/tests/Feature/DniNieRuleTest.php
+++ b/tests/Feature/DniNieRuleTest.php
@@ -2,11 +2,11 @@
 
 namespace Tests\Feature;
 
-use App\Rules\DniRule;
+use App\Rules\DniNieRule;
 use Illuminate\Support\Facades\Validator;
 use Tests\TestCase;
 
-class DniRuleTest extends TestCase
+class DniNieRuleTest extends TestCase
 {
     /**
      * A basic feature test example.
@@ -15,7 +15,7 @@ class DniRuleTest extends TestCase
     public function test_valid_nif_passes_validation()
     {
         $validator = Validator::make(['dni' => '83749707Z'], [
-            'dni' => [new DniRule()],
+            'dni' => [new DniNieRule()],
         ]);
 
         $this->assertTrue($validator->passes());
@@ -25,7 +25,7 @@ class DniRuleTest extends TestCase
     public function test_invalid_nif_fails_validation()
     {
         $validator = Validator::make(['dni' => '12345678B'], [
-            'dni' => [new DniRule()],
+            'dni' => [new DniNieRule()],
         ]);
 
         $this->assertFalse($validator->passes());
@@ -35,7 +35,7 @@ class DniRuleTest extends TestCase
     public function test_valid_nie_passes_validation()
     {
         $validator = Validator::make(['dni' => 'X7959970S'], [
-            'dni' => [new DniRule()],
+            'dni' => [new DniNieRule()],
         ]);
 
         $this->assertTrue($validator->passes());
@@ -45,7 +45,7 @@ class DniRuleTest extends TestCase
     public function test_invalid_nie_fails_validation()
     {
         $validator = Validator::make(['dni' => 'X1234567C'], [
-            'dni' => [new DniRule()],
+            'dni' => [new DniNieRule()],
         ]);
 
         $this->assertFalse($validator->passes());

--- a/tests/Feature/LoginControllerTest.php
+++ b/tests/Feature/LoginControllerTest.php
@@ -29,7 +29,7 @@ class LoginControllerTest extends TestCase
             'password' => 'password123',
         ];
 
-        $response = $this->post(route('login'), $credentials);
+        $response = $this->postJson(route('login'), $credentials);
 
         $response->assertStatus(200)->assertJsonStructure(['token']);
     }
@@ -45,7 +45,7 @@ class LoginControllerTest extends TestCase
             'password' => '123456',
         ];
 
-        $response = $this->post(route('login'), $credentials);
+        $response = $this->postJson(route('login'), $credentials);
 
         $response->assertStatus(422);
     }
@@ -54,7 +54,7 @@ class LoginControllerTest extends TestCase
     {
         User::factory()->create();
 
-        $response = $this->json('POST', '/api/v1/login');
+        $response =$this->postJson(route('login'));
         $response->assertStatus(422)
             ->assertJsonValidationErrors(['dni', 'password'])
             ->assertJson([
@@ -74,7 +74,7 @@ class LoginControllerTest extends TestCase
 
         $response->assertStatus(401);
         $response->assertJson([
-            'message' => __('Dni-Nie o contrasenya incorrecte'),
+            'message' => __('Credencials invàlides, comprova-les i torneu a iniciar sessió'),
         ]);
     }
 
@@ -83,7 +83,7 @@ class LoginControllerTest extends TestCase
         $user = User::factory()->create();
         $this->actingAs($user, 'api');
 
-        $response = $this->postJson('/api/v1/logout');
+        $response =$this->postJson(route('logout'));
 
         $response->assertStatus(200);
 
@@ -97,7 +97,7 @@ class LoginControllerTest extends TestCase
 
         User::factory()->create();
 
-        $response = $this->postJson('/api/v1/logout');
+        $response = $this->postJson(route('logout'));
 
         $response->assertStatus(401);
 

--- a/tests/Feature/LoginControllerTest.php
+++ b/tests/Feature/LoginControllerTest.php
@@ -17,12 +17,12 @@ class LoginControllerTest extends TestCase
     public function test_Login_Success()
     {
         $user = User::factory()->create([
-            'email' => 'pruebalogin@test.com',
+            'dni' => '28386914S',
             'password' => bcrypt('password123'),
         ]);
 
         $requestData = [
-            'email' => 'pruebalogin@test.com',
+            'dni' => '28386914S',
             'password' => 'password123',
         ];
 
@@ -35,11 +35,11 @@ class LoginControllerTest extends TestCase
     public function test_a_user_can_login_with_short_password()
     {
         $user = User::factory()->create([
-            'email' => fake()->email(),
+            'dni' => 'Z0038540C',
             'password' => '12345678',
         ]);
         $credentials = [
-            'email' => 'jose@gmail.com',
+            'dni' => '28386914S',
             'password' => '123456',
         ];
 
@@ -49,20 +49,20 @@ class LoginControllerTest extends TestCase
 
     }
 
-    public function test_a_user_can_login_with_not_email()
+    public function test_a_user_can_login_with_not_dni()
     {
         $user = User::factory()->create();
         $credentials = [
-            'email',
+            'dni',
             'password' => '12345678',
         ];
 
         $response = $this->json('POST', '/api/v1/login');
         $response->assertStatus(422)
-            ->assertJsonValidationErrors(['email', 'password'])
+            ->assertJsonValidationErrors(['dni', 'password'])
             ->assertJson([
                 'errors' => [
-                    'email' => [__('El camp adreça electrònica és obligatori.')],
+                    'dni' => [__('El camp dni és obligatori.')],
                     'password' => [__('El camp contrasenya és obligatori.')],
                 ],
             ]);
@@ -72,13 +72,13 @@ class LoginControllerTest extends TestCase
     public function test_login_failure_bad_data()
     {
         $response = $this->post('/api/v1/login', [
-            'email' => 'invalid@example.com',
+            'dni' => 'Z0038540C',
             'password' => 'wrongpassword',
         ]);
 
         $response->assertStatus(401);
         $response->assertJson([
-            'message' => __('Email o contrasenya incorrecte'),
+            'message' => __('Dni-Nie o contrasenya incorrecte'),
         ]);
 
     }

--- a/tests/Feature/Student/StudentDeleteTest.php
+++ b/tests/Feature/Student/StudentDeleteTest.php
@@ -101,7 +101,5 @@ class StudentDeleteTest extends TestCase
 
         $response->status(401);
 
-
-
     }
 }

--- a/tests/Feature/Student/StudentListTest.php
+++ b/tests/Feature/Student/StudentListTest.php
@@ -14,6 +14,7 @@ class StudentListTest extends TestCase
 
         $this->artisan('passport:install');
     }
+
     public function verifyOrCreateRole()
     {
         if (!Role::where('name', 'student')->exists()) {
@@ -47,6 +48,4 @@ class StudentListTest extends TestCase
         $response->assertHeader('Content-Type', 'application/json');
 
     }
-
-
 }

--- a/tests/Feature/Student/StudentUpdateTest.php
+++ b/tests/Feature/Student/StudentUpdateTest.php
@@ -17,7 +17,6 @@ class StudentUpdateTest extends TestCase
         $this->artisan('passport:install');
     }
 
-
     public function verifyOrCreateRolesAndPermissions()
     {
         if (!Role::where('name', 'student')->exists()) {
@@ -56,8 +55,6 @@ class StudentUpdateTest extends TestCase
         ]);
 
         $this->assertAuthenticatedAs($user);
-
-
 
         $data = [
             'name' => 'Johnny',
@@ -108,7 +105,6 @@ class StudentUpdateTest extends TestCase
             'email' => fake()->email(),
             'password' => $password,
         ]);
-
 
         $this->actingAs($user, 'api');
 


### PR DESCRIPTION
#38 

## Changes in LoginController and Test Refactoring

### Changes in LoginController

- The `login` method was updated to allow logging in using the "dni" field instead of "email". This involved modifying the authentication logic to support logging in using the identification number (DNI/NIE).

### Test Refactoring

- Existing tests were refactored to reflect the changes made in the `LoginController`. This included updating authentication tests to use the new "dni" field instead of "email" when logging in.