### PR TITLE
feature: extract to a service and update the update resume controller

### DIFF
--- a/app/Annotations/OpenApi/AnnotationsInfo.php
+++ b/app/Annotations/OpenApi/AnnotationsInfo.php
@@ -18,6 +18,4 @@ namespace App\Annotations\OpenApi;
  *     url="http://127.0.0.1:8000/api/v1"
  *   )
  */
-class AnnotationsInfo
-{
-}
+class AnnotationsInfo {}

--- a/app/Annotations/OpenApi/controllersAnnotations/StudentAnnotations/AnnotationsStudent.php
+++ b/app/Annotations/OpenApi/controllersAnnotations/StudentAnnotations/AnnotationsStudent.php
@@ -42,9 +42,7 @@ class AnnotationsStudent
      *     )
      * )
      */
-    public function index()
-    {
-    }
+    public function index() {}
 
     /**
      * Crea un estudiant
@@ -108,9 +106,7 @@ class AnnotationsStudent
      *      ),
      * )
      */
-    public function store()
-    {
-    }
+    public function store() {}
 
     /**
      * Detalls d'un estudiant
@@ -167,9 +163,7 @@ class AnnotationsStudent
      *     ),
      * )
      */
-    public function show()
-    {
-    }
+    public function show() {}
 
     /**
      * Actualitza les dades d'un estudiant
@@ -253,9 +247,7 @@ class AnnotationsStudent
      *      )
      * )
      */
-    public function update()
-    {
-    }
+    public function update() {}
 
     /**
      * @OA\Delete(
@@ -309,7 +301,5 @@ class AnnotationsStudent
      *      )
      * )
      */
-    public function delete()
-    {
-    }
+    public function delete() {}
 }

--- a/app/Annotations/OpenApi/controllersAnnotations/adminAnnotations/AnnotationsAdmin.php
+++ b/app/Annotations/OpenApi/controllersAnnotations/adminAnnotations/AnnotationsAdmin.php
@@ -42,9 +42,7 @@ class AnnotationsAdmin
      *      ),
      * )
      */
-    public function index()
-    {
-    }
+    public function index() {}
 
     /**
      * @OA\Post(
@@ -99,9 +97,7 @@ class AnnotationsAdmin
      *
      * )
      */
-    public function store()
-    {
-    }
+    public function store() {}
 
     /**
      * @OA\Get(
@@ -147,9 +143,7 @@ class AnnotationsAdmin
      *      ),
      * )
      */
-    public function show()
-    {
-    }
+    public function show() {}
 
     /**
      * @OA\Put(
@@ -233,9 +227,7 @@ class AnnotationsAdmin
      *      ),
      * )
      */
-    public function update()
-    {
-    }
+    public function update() {}
 
     /**
      * @OA\Delete(
@@ -289,7 +281,5 @@ class AnnotationsAdmin
      *      )
      * )
      */
-    public function delete()
-    {
-    }
+    public function delete() {}
 }

--- a/app/Annotations/OpenApi/controllersAnnotations/authAnnotations/AnnotationsAuth.php
+++ b/app/Annotations/OpenApi/controllersAnnotations/authAnnotations/AnnotationsAuth.php
@@ -48,9 +48,7 @@ class AnnotationsAuth
      *      ),
      * )
      */
-    public function login()
-    {
-    }
+    public function login() {}
 
     /**
      * @OA\Post(
@@ -75,7 +73,5 @@ class AnnotationsAuth
      *      ),
      * )
      */
-    public function logout()
-    {
-    }
+    public function logout() {}
 }

--- a/app/Annotations/OpenApi/controllersAnnotations/recruiterAnnotations/AnnotationsRecruiter.php
+++ b/app/Annotations/OpenApi/controllersAnnotations/recruiterAnnotations/AnnotationsRecruiter.php
@@ -43,9 +43,7 @@ class AnnotationsRecruiter
      *     )
      * )
      */
-    public function index()
-    {
-    }
+    public function index() {}
 
     /**
      * @OA\Post(
@@ -102,9 +100,7 @@ class AnnotationsRecruiter
      *
      * )
      */
-    public function store()
-    {
-    }
+    public function store() {}
 
     /**
      * @OA\Get(
@@ -147,9 +143,7 @@ class AnnotationsRecruiter
      *      ),
      * )
      */
-    public function show()
-    {
-    }
+    public function show() {}
 
     /**
      * @OA\Put(
@@ -205,9 +199,7 @@ class AnnotationsRecruiter
      *      ),
      * )
      */
-    public function update()
-    {
-    }
+    public function update() {}
 
     /**
      * @OA\Delete(
@@ -261,7 +253,5 @@ class AnnotationsRecruiter
      *      )
      * )
      */
-    public function delete()
-    {
-    }
+    public function delete() {}
 }

--- a/app/Annotations/OpenApi/controllersAnnotations/resumeAnnotations/AnnotationsResume.php
+++ b/app/Annotations/OpenApi/controllersAnnotations/resumeAnnotations/AnnotationsResume.php
@@ -1,62 +1,63 @@
 <?php
+
 namespace App\Annotations\OpenApi\controllersAnnotations\resumeAnnotations;
 
 class AnnotationsResume
 {
- /**
- * @OA\Put(
- *      path="/resume/{id}",
- *      operationId="updateResume",
- *      tags={"Resumes"},
- *      summary="Update a resume",
- *      description="Update an existing resume. Authentication is required.",
- *      security={{"bearerAuth": {}}},
- *
- *      @OA\Parameter(
- *          name="id",
- *          in="path",
- *          description="ID of the resume to be updated",
- *          required=true,
- *          @OA\Schema(type="string"),
- *      ),
- *
- *      @OA\RequestBody(
- *          required=true,
- *          description="Data to be updated",
- *          @OA\JsonContent(
- *              type="object",
- *              @OA\Property(property="subtitle", type="string", example="New Subtitle"),
- *              @OA\Property(property="linkedin_url", type="string", format="url", example="https://www.linkedin.com"),
- *              @OA\Property(property="github_url", type="string", format="url", example="https://www.github.com"),
- *              @OA\Property(property="specialization", type="enum", enum={"Frontend", "Backend", "Fullstack", "Data Science", "Not Set"}, example="Backend"),
- *          )
- *      ),
- *
- *      @OA\Response(
- *          response=200,
- *          description="Success. Returns updated resume details.",
- *          @OA\JsonContent(
- *              type="object",
- *              @OA\Property(property="subtitle", type="string", example="New Subtitle"),
- *              @OA\Property(property="linkedin_url", type="string", format="url", example="https://www.linkedin.com"),
- *              @OA\Property(property="github_url", type="string", format="url", example="https://www.github.com"),
- *              @OA\Property(property="specialization", type="enum", enum={"Frontend", "Backend", "Fullstack", "Data Science", "Not Set"}, example="Backend"),
- *          )
- *      ),
- *
- *      @OA\Response(
- *          response=401,
- *          description="You do not have permission to modify this resume"
- *      ),
- *      @OA\Response(
- *          response=404,
- *          description="Not Found. Resume with specified ID not found."
- *      ),
- * )
- */
+    /**
+    * @OA\Put(
+    *      path="/resume/{id}",
+    *      operationId="updateResume",
+    *      tags={"Resumes"},
+    *      summary="Update a resume",
+    *      description="Update an existing resume. Authentication is required.",
+    *      security={{"bearerAuth": {}}},
+    *
+    *      @OA\Parameter(
+    *          name="id",
+    *          in="path",
+    *          description="ID of the resume to be updated",
+    *          required=true,
+    *          @OA\Schema(type="string"),
+    *      ),
+    *
+    *      @OA\RequestBody(
+    *          required=true,
+    *          description="Data to be updated",
+    *          @OA\JsonContent(
+    *              type="object",
+    *              @OA\Property(property="subtitle", type="string", example="New Subtitle"),
+    *              @OA\Property(property="linkedin_url", type="string", format="url", example="https://www.linkedin.com"),
+    *              @OA\Property(property="github_url", type="string", format="url", example="https://www.github.com"),
+    *              @OA\Property(property="specialization", type="enum", enum={"Frontend", "Backend", "Fullstack", "Data Science", "Not Set"}, example="Backend"),
+    *          )
+    *      ),
+    *
+    *      @OA\Response(
+    *          response=200,
+    *          description="Success. Returns updated resume details.",
+    *          @OA\JsonContent(
+    *              type="object",
+    *              @OA\Property(property="subtitle", type="string", example="New Subtitle"),
+    *              @OA\Property(property="linkedin_url", type="string", format="url", example="https://www.linkedin.com"),
+    *              @OA\Property(property="github_url", type="string", format="url", example="https://www.github.com"),
+    *              @OA\Property(property="specialization", type="enum", enum={"Frontend", "Backend", "Fullstack", "Data Science", "Not Set"}, example="Backend"),
+    *          )
+    *      ),
+    *
+    *      @OA\Response(
+    *          response=401,
+    *          description="You do not have permission to modify this resume"
+    *      ),
+    *      @OA\Response(
+    *          response=404,
+    *          description="Not Found. Resume with specified ID not found."
+    *      ),
+    * )
+    */
 
-    public function update(){}
-    
+    public function update() {}
+
     /**
  * @OA\Delete(
  *      path="/resume/{id}",
@@ -99,5 +100,5 @@ class AnnotationsResume
  */
 
 
-    public function delete(){}
+    public function delete() {}
 }

--- a/app/Annotations/OpenApi/controllersAnnotations/specializationListAnnotations/AnnotationsSpecializationList.php
+++ b/app/Annotations/OpenApi/controllersAnnotations/specializationListAnnotations/AnnotationsSpecializationList.php
@@ -24,7 +24,5 @@ class AnnotationsSpecializationList
      *     )
      * )
      */
-    public function __invoke()
-    {
-    }
+    public function __invoke() {}
 }

--- a/app/Annotations/OpenApi/controllersAnnotations/tagAnnotations/AnnotationsTag.php
+++ b/app/Annotations/OpenApi/controllersAnnotations/tagAnnotations/AnnotationsTag.php
@@ -54,9 +54,7 @@ class AnnotationsTag
      *     )
      * )
      */
-    public function index()
-    {
-    }
+    public function index() {}
 
     /**
      * @OA\Post(
@@ -101,9 +99,7 @@ class AnnotationsTag
      *     ),
      * )
      */
-    public function store()
-    {
-    }
+    public function store() {}
 
     /**
      * @OA\Get(
@@ -154,9 +150,7 @@ class AnnotationsTag
      *     ),
      *   )
      */
-    public function show()
-    {
-    }
+    public function show() {}
 
     /**
      * @OA\Put(
@@ -217,9 +211,7 @@ class AnnotationsTag
      *     ),
      * )
      */
-    public function update()
-    {
-    }
+    public function update() {}
 
     /**
      * @OA\Delete(
@@ -260,7 +252,5 @@ class AnnotationsTag
      *     ),
      * )
      */
-    public function delete()
-    {
-    }
+    public function delete() {}
 }

--- a/app/Annotations/OpenApi/modelsAnnotations/adminAnnotations/AnnotationsAdmin.php
+++ b/app/Annotations/OpenApi/modelsAnnotations/adminAnnotations/AnnotationsAdmin.php
@@ -48,6 +48,4 @@ namespace App\Annotations\OpenApi\modelsAnnotations\adminAnnotations;
  *
  * @var \Illuminate\Support\Carbon
  */
-class AnnotationsAdmin
-{
-}
+class AnnotationsAdmin {}

--- a/app/Annotations/OpenApi/modelsAnnotations/recruiterAnnotations/AnnotationsRecruiter.php
+++ b/app/Annotations/OpenApi/modelsAnnotations/recruiterAnnotations/AnnotationsRecruiter.php
@@ -57,6 +57,4 @@ namespace App\Annotations\OpenApi\modelsAnnotations\recruiterAnnotations;
  *
  * @var \Illuminate\Support\Carbon
  */
-class AnnotationsRecruiter
-{
-}
+class AnnotationsRecruiter {}

--- a/app/Annotations/OpenApi/modelsAnnotations/resumeAnnotations/AnnotationsResume.php
+++ b/app/Annotations/OpenApi/modelsAnnotations/resumeAnnotations/AnnotationsResume.php
@@ -1,4 +1,5 @@
-<?php 
+<?php
+
 namespace App\Annotations\OpenApi\modelsAnnotations\resumeAnnotations;
 
 /**
@@ -24,7 +25,7 @@ namespace App\Annotations\OpenApi\modelsAnnotations\resumeAnnotations;
  *     property="student_id",
  *     description="ID of the associated students",
  *     type="string",
- *    
+ *
  * )
  *
  * @var string
@@ -58,9 +59,9 @@ namespace App\Annotations\OpenApi\modelsAnnotations\resumeAnnotations;
  *     description="Student Bootcamp's specialization",
  *     type="enum"
  * )
- * 
  *
- * 
+ *
+ *
  *
  * @OA\Property(
  *     property="tags_ids",
@@ -93,6 +94,4 @@ namespace App\Annotations\OpenApi\modelsAnnotations\resumeAnnotations;
 */
 
 
-class AnnotationsResume
-{
-}
+class AnnotationsResume {}

--- a/app/Annotations/OpenApi/modelsAnnotations/studentAnnotations/AnnotationsStudent.php
+++ b/app/Annotations/OpenApi/modelsAnnotations/studentAnnotations/AnnotationsStudent.php
@@ -101,6 +101,4 @@ namespace App\Annotations\OpenApi\modelsAnnotations\studentAnnotations;
  *
  * @var \Illuminate\Support\Carbon
  */
-class AnnotationsStudent
-{
-}
+class AnnotationsStudent {}

--- a/app/Annotations/OpenApi/modelsAnnotations/tagAnnotations/AnnotationsTag.php
+++ b/app/Annotations/OpenApi/modelsAnnotations/tagAnnotations/AnnotationsTag.php
@@ -48,6 +48,4 @@ namespace App\Annotations\OpenApi\modelsAnnotations\tagAnnotations;
  *
  * @var \Illuminate\Support\Carbon
  */
-class AnnotationsTag
-{
-}
+class AnnotationsTag {}

--- a/app/Annotations/OpenApi/modelsAnnotations/userAnnotations/AnnotationsUser.php
+++ b/app/Annotations/OpenApi/modelsAnnotations/userAnnotations/AnnotationsUser.php
@@ -96,6 +96,4 @@ namespace App\Annotations\OpenApi\modelsAnnotations\userAnnotations;
  *
  * @var \Illuminate\Support\Carbon|null
  */
-class AnnotationsUser
-{
-}
+class AnnotationsUser {}

--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -20,7 +20,7 @@ class Kernel extends ConsoleKernel
      */
     protected function commands(): void
     {
-        $this->load(__DIR__.'/Commands');
+        $this->load(__DIR__ . '/Commands');
 
         require base_path('routes/console.php');
     }

--- a/app/Http/Controllers/api/ResumeController.php
+++ b/app/Http/Controllers/api/ResumeController.php
@@ -4,13 +4,11 @@ namespace App\Http\Controllers\api;
 
 use App\Exceptions\UserNotAuthenticatedException;
 use App\Http\Controllers\Controller;
-use App\Http\Resources\ResumeShowResource;
 use App\Models\Resume;
 use App\Service\Resume\ResumeUpdateService;
 use Illuminate\Database\Eloquent\ModelNotFoundException;
 use Illuminate\Http\Exceptions\HttpResponseException;
 use Illuminate\Http\Request;
-
 
 class ResumeController extends Controller
 {
@@ -32,10 +30,7 @@ class ResumeController extends Controller
     /**
      * Store a newly created resource in storage.
      */
-    public function store(Request $request)
-    {
-
-    }
+    public function store(Request $request) {}
 
     /**
      * Display the specified resource.

--- a/app/Http/Controllers/api/ResumeController.php
+++ b/app/Http/Controllers/api/ResumeController.php
@@ -54,10 +54,10 @@ class ResumeController extends Controller
             $data = $request->all();
             $this->resumeUpdateService->execute(
                 $id,
-                $data['subtitle'],
-                $data['linkedin_url'],
-                $data['github_url'],
-                $data['specialization']
+                $data['subtitle'] ?? null,
+                $data['linkedin_url'] ?? null,
+                $data['github_url'] ?? null,
+                $data['specialization'] ?? null
             );
 
             return response('', 200);

--- a/app/Http/Controllers/api/ResumeController.php
+++ b/app/Http/Controllers/api/ResumeController.php
@@ -6,6 +6,7 @@ use App\Exceptions\UserNotAuthenticatedException;
 use App\Http\Controllers\Controller;
 use App\Http\Resources\ResumeShowResource;
 use App\Models\Resume;
+use App\Service\Resume\ResumeUpdateService;
 use Illuminate\Database\Eloquent\ModelNotFoundException;
 use Illuminate\Http\Exceptions\HttpResponseException;
 use Illuminate\Http\Request;
@@ -13,6 +14,13 @@ use Illuminate\Http\Request;
 
 class ResumeController extends Controller
 {
+    private ResumeUpdateService $resumeUpdateService;
+
+    public function __construct(ResumeUpdateService $resumeUpdateService)
+    {
+        $this->resumeUpdateService = $resumeUpdateService;
+    }
+
     /**
      * Display a listing of the resource.
      */
@@ -26,7 +34,7 @@ class ResumeController extends Controller
      */
     public function store(Request $request)
     {
-       
+
     }
 
     /**
@@ -44,23 +52,29 @@ class ResumeController extends Controller
     {
         try {
             $data = $request->all();
-            $resume = Resume::updateResume($data, $id);
+            $this->resumeUpdateService->execute(
+                $id,
+                $data['subtitle'],
+                $data['linkedin_url'],
+                $data['github_url'],
+                $data['specialization']
+            );
 
-            return response()->json(['resume' =>new ResumeShowResource( $resume)], 200);
-
+            return response('', 200);
         } catch (ModelNotFoundException $resumeNotFoundExeption) {
 
             throw new HttpResponseException(response()->json([
                 'message' => __(
                     $resumeNotFoundExeption->getMessage()
-                )], $resumeNotFoundExeption->getCode()));
+                )
+            ], $resumeNotFoundExeption->getCode()));
         } catch (UserNotAuthenticatedException $userNotAuthException) {
             throw new HttpResponseException(response()->json([
                 'message' => __(
                     $userNotAuthException->getMessage()
-                )], $userNotAuthException->getHttpCode()));
+                )
+            ], $userNotAuthException->getHttpCode()));
         }
-
     }
 
     /**
@@ -77,13 +91,14 @@ class ResumeController extends Controller
             throw new HttpResponseException(response()->json([
                 'message' => __(
                     $resumeNotFoundExeption->getMessage()
-                )], $resumeNotFoundExeption->getCode()));
+                )
+            ], $resumeNotFoundExeption->getCode()));
         } catch (UserNotAuthenticatedException $userNotAuthException) {
             throw new HttpResponseException(response()->json([
                 'message' => __(
                     $userNotAuthException->getMessage()
-                )], $userNotAuthException->getHttpCode()));
+                )
+            ], $userNotAuthException->getHttpCode()));
         }
-
     }
 }

--- a/app/Http/Kernel.php
+++ b/app/Http/Kernel.php
@@ -40,7 +40,7 @@ class Kernel extends HttpKernel
 
         'api' => [
             // \Laravel\Sanctum\Http\Middleware\EnsureFrontendRequestsAreStateful::class,
-            \Illuminate\Routing\Middleware\ThrottleRequests::class.':api',
+            \Illuminate\Routing\Middleware\ThrottleRequests::class . ':api',
             \Illuminate\Routing\Middleware\SubstituteBindings::class,
         ],
     ];

--- a/app/Http/Resources/ResumeShowResource.php
+++ b/app/Http/Resources/ResumeShowResource.php
@@ -19,7 +19,7 @@ class ResumeShowResource extends JsonResource
             'subtitle' => $this->subtitle,
             'specialization' => $this->specialization,
             'tags_ids' => $this->tags_ids,
-        
+
         ];
     }
 }

--- a/app/Models/Resume.php
+++ b/app/Models/Resume.php
@@ -17,38 +17,6 @@ class Resume extends Model
 
     public function student()
     {
-        return $this->belongsTo(Student::class);
-    }
-
-    public static function updateResume($data, $id)
-    {
-        $instance = new self();
-        $resume = $instance->validateAndRetrieveResume($id);
-        $resume->update($data);
-
-        return $resume;
-
-    }
-
-    public static function deleteResume($id)
-    {
-        $instance = new self();
-        $resume = $instance->validateAndRetrieveResume($id);
-        $resume->delete();
-    }
-
-    private function validateAndRetrieveResume($id)
-    {
-        $resumeId = Auth::user()->student->resume->id;
-        $resume = Resume::find($id);
-        if (!$resume) {
-            throw new ModelNotFoundException(
-                __('Currículum no trobat'), 404);
-        }
-        if ($resumeId != $resume->id) {
-            throw new UserNotAuthenticatedException();
-        } 
-
-        return $resume;
+        return $this->belongsTo(Student::class, 'id', 'student_id');
     }
 }

--- a/app/Models/Resume.php
+++ b/app/Models/Resume.php
@@ -2,16 +2,14 @@
 
 namespace App\Models;
 
-use App\Exceptions\UserNotAuthenticatedException;
 use Illuminate\Database\Eloquent\Concerns\HasUuids;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
-use Illuminate\Database\Eloquent\ModelNotFoundException;
-use Illuminate\Support\Facades\Auth;
 
 class Resume extends Model
 {
-    use HasFactory, HasUuids;
+    use HasFactory;
+    use HasUuids;
 
     protected $fillable = ['student_id', 'subtitle', 'linkedin_url', 'github_url', 'tags_ids', 'specialization'];
 

--- a/app/Service/Resume/ResumeUpdateService.php
+++ b/app/Service/Resume/ResumeUpdateService.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Service\Resume;
+
+use App\Models\Resume;
+
+class ResumeUpdateService
+{
+    public function execute(
+        string $resumeId,
+        ?string $subtitle = null,
+        ?string $linkedinUrl = null,
+        ?string $githubUrl = null,
+        ?string $specialization = null
+    ): void {
+        $resume = Resume::find($resumeId);
+
+        if ($subtitle !== null) {
+            $resume->subtitle = $subtitle;
+        }
+
+        if ($linkedinUrl !== null) {
+            $resume->linkedin_url = $linkedinUrl;
+        }
+
+        if ($githubUrl !== null) {
+            $resume->github_url = $githubUrl;
+        }
+
+        if ($specialization !== null) {
+            $resume->specialization = $specialization;
+        }
+
+        $resume->save();
+    }
+}

--- a/config/broadcasting.php
+++ b/config/broadcasting.php
@@ -37,7 +37,7 @@ return [
             'app_id' => env('PUSHER_APP_ID'),
             'options' => [
                 'cluster' => env('PUSHER_APP_CLUSTER'),
-                'host' => env('PUSHER_HOST') ?: 'api-'.env('PUSHER_APP_CLUSTER', 'mt1').'.pusher.com',
+                'host' => env('PUSHER_HOST') ?: 'api-' . env('PUSHER_APP_CLUSTER', 'mt1') . '.pusher.com',
                 'port' => env('PUSHER_PORT', 443),
                 'scheme' => env('PUSHER_SCHEME', 'https'),
                 'encrypted' => true,

--- a/config/cache.php
+++ b/config/cache.php
@@ -106,6 +106,6 @@ return [
     |
     */
 
-    'prefix' => env('CACHE_PREFIX', Str::slug(env('APP_NAME', 'laravel'), '_').'_cache_'),
+    'prefix' => env('CACHE_PREFIX', Str::slug(env('APP_NAME', 'laravel'), '_') . '_cache_'),
 
 ];

--- a/config/database.php
+++ b/config/database.php
@@ -125,7 +125,7 @@ return [
 
         'options' => [
             'cluster' => env('REDIS_CLUSTER', 'redis'),
-            'prefix' => env('REDIS_PREFIX', Str::slug(env('APP_NAME', 'laravel'), '_').'_database_'),
+            'prefix' => env('REDIS_PREFIX', Str::slug(env('APP_NAME', 'laravel'), '_') . '_database_'),
         ],
 
         'default' => [

--- a/config/filesystems.php
+++ b/config/filesystems.php
@@ -39,7 +39,7 @@ return [
         'public' => [
             'driver' => 'local',
             'root' => storage_path('app/public'),
-            'url' => env('APP_URL').'/storage',
+            'url' => env('APP_URL') . '/storage',
             'visibility' => 'public',
             'throw' => false,
         ],

--- a/config/logging.php
+++ b/config/logging.php
@@ -89,7 +89,7 @@ return [
             'handler_with' => [
                 'host' => env('PAPERTRAIL_URL'),
                 'port' => env('PAPERTRAIL_PORT'),
-                'connectionString' => 'tls://'.env('PAPERTRAIL_URL').':'.env('PAPERTRAIL_PORT'),
+                'connectionString' => 'tls://' . env('PAPERTRAIL_URL') . ':' . env('PAPERTRAIL_PORT'),
             ],
             'processors' => [PsrLogMessageProcessor::class],
         ],

--- a/config/session.php
+++ b/config/session.php
@@ -128,7 +128,7 @@ return [
 
     'cookie' => env(
         'SESSION_COOKIE',
-        Str::slug(env('APP_NAME', 'laravel'), '_').'_session'
+        Str::slug(env('APP_NAME', 'laravel'), '_') . '_session'
     ),
 
     /*

--- a/database/factories/UserFactory.php
+++ b/database/factories/UserFactory.php
@@ -35,7 +35,7 @@ class UserFactory extends Factory
      */
     public function unverified(): static
     {
-        return $this->state(fn (array $attributes) => [
+        return $this->state(fn(array $attributes) => [
             'email_verified_at' => null,
         ]);
     }

--- a/database/migrations/2014_10_12_000000_create_users_table.php
+++ b/database/migrations/2014_10_12_000000_create_users_table.php
@@ -4,8 +4,7 @@ use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 
-return new class() extends Migration
-{
+return new class () extends Migration {
     /**
      * Run the migrations.
      */

--- a/database/migrations/2014_10_12_100000_create_password_reset_tokens_table.php
+++ b/database/migrations/2014_10_12_100000_create_password_reset_tokens_table.php
@@ -4,8 +4,7 @@ use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 
-return new class() extends Migration
-{
+return new class () extends Migration {
     /**
      * Run the migrations.
      */

--- a/database/migrations/2019_08_19_000000_create_failed_jobs_table.php
+++ b/database/migrations/2019_08_19_000000_create_failed_jobs_table.php
@@ -4,8 +4,7 @@ use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 
-return new class() extends Migration
-{
+return new class () extends Migration {
     /**
      * Run the migrations.
      */

--- a/database/migrations/2019_12_14_000001_create_personal_access_tokens_table.php
+++ b/database/migrations/2019_12_14_000001_create_personal_access_tokens_table.php
@@ -4,8 +4,7 @@ use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 
-return new class() extends Migration
-{
+return new class () extends Migration {
     /**
      * Run the migrations.
      */

--- a/database/migrations/2023_10_28_173326_create_students_table.php
+++ b/database/migrations/2023_10_28_173326_create_students_table.php
@@ -4,8 +4,7 @@ use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 
-return new class() extends Migration
-{
+return new class () extends Migration {
     /**
      * Run the migrations.
      */

--- a/database/migrations/2023_11_06_112200_create_admins_table.php
+++ b/database/migrations/2023_11_06_112200_create_admins_table.php
@@ -4,8 +4,7 @@ use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 
-return new class() extends Migration
-{
+return new class () extends Migration {
     /**
      * Run the migrations.
      */

--- a/database/migrations/2023_11_13_102833_create_recruiters_table.php
+++ b/database/migrations/2023_11_13_102833_create_recruiters_table.php
@@ -4,8 +4,7 @@ use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 
-return new class() extends Migration
-{
+return new class () extends Migration {
     /**
      * Run the migrations.
      */

--- a/database/migrations/2024_01_10_110947_create_tags_table.php
+++ b/database/migrations/2024_01_10_110947_create_tags_table.php
@@ -4,8 +4,7 @@ use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 
-return new class() extends Migration
-{
+return new class () extends Migration {
     /**
      * Run the migrations.
      */

--- a/database/migrations/2024_01_10_121633_create_student_has_tags_table.php
+++ b/database/migrations/2024_01_10_121633_create_student_has_tags_table.php
@@ -4,8 +4,7 @@ use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 
-return new class() extends Migration
-{
+return new class () extends Migration {
     /**
      * Run the migrations.
      */

--- a/database/migrations/2024_02_07_095416_create_resumes_table.php
+++ b/database/migrations/2024_02_07_095416_create_resumes_table.php
@@ -5,8 +5,7 @@ use Illuminate\Database\Query\Expression;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 
-return new class extends Migration
-{
+return new class () extends Migration {
     /**
      * Run the migrations.
      */

--- a/public/index.php
+++ b/public/index.php
@@ -16,7 +16,7 @@ define('LARAVEL_START', microtime(true));
 |
 */
 
-if (file_exists($maintenance = __DIR__.'/../storage/framework/maintenance.php')) {
+if (file_exists($maintenance = __DIR__ . '/../storage/framework/maintenance.php')) {
     require $maintenance;
 }
 
@@ -31,7 +31,7 @@ if (file_exists($maintenance = __DIR__.'/../storage/framework/maintenance.php'))
 |
 */
 
-require __DIR__.'/../vendor/autoload.php';
+require __DIR__ . '/../vendor/autoload.php';
 
 /*
 |--------------------------------------------------------------------------
@@ -44,7 +44,7 @@ require __DIR__.'/../vendor/autoload.php';
 |
 */
 
-$app = require_once __DIR__.'/../bootstrap/app.php';
+$app = require_once __DIR__ . '/../bootstrap/app.php';
 
 $kernel = $app->make(Kernel::class);
 

--- a/tests/CreatesApplication.php
+++ b/tests/CreatesApplication.php
@@ -12,7 +12,7 @@ trait CreatesApplication
      */
     public function createApplication(): Application
     {
-        $app = require __DIR__.'/../bootstrap/app.php';
+        $app = require __DIR__ . '/../bootstrap/app.php';
 
         $app->make(Kernel::class)->bootstrap();
 

--- a/tests/Feature/Recruiter/RecruiterRegisterTest.php
+++ b/tests/Feature/Recruiter/RecruiterRegisterTest.php
@@ -100,8 +100,8 @@ class RecruiterRegisterTest extends TestCase
         $numbers = str_pad(mt_rand(1, 99999999), 7, '0', STR_PAD_LEFT);
         $letters = 'TRWAGMYFPDXBNJZSQVHLCKE';
 
-        $checkDigit = $letters[($randomPrefix.$numbers) % 23];
+        $checkDigit = $letters[($randomPrefix . $numbers) % 23];
 
-        return $randomPrefix.$numbers.$checkDigit;
+        return $randomPrefix . $numbers . $checkDigit;
     }
 }

--- a/tests/Feature/Student/StudentDeleteTest.php
+++ b/tests/Feature/Student/StudentDeleteTest.php
@@ -58,7 +58,7 @@ class StudentDeleteTest extends TestCase
 
         $this->actingAs($user, 'api');
 
-        $response = $this->withHeaders(['Accept' => 'application/json'])->delete('api/v1/students/'.$user->student->id);
+        $response = $this->withHeaders(['Accept' => 'application/json'])->delete('api/v1/students/' . $user->student->id);
 
         $response->assertStatus(200);
         $response->assertHeader('Content-Type', 'application/json');

--- a/tests/Feature/Student/StudentShowTest.php
+++ b/tests/Feature/Student/StudentShowTest.php
@@ -42,7 +42,7 @@ class StudentShowTest extends TestCase
 
         $user->assignRole('student');
 
-        $response = $this->get('api/v1/students/'.$user->student->id);
+        $response = $this->get('api/v1/students/' . $user->student->id);
 
         $response->assertStatus(200);
         $response->assertHeader('Content-Type', 'application/json');

--- a/tests/Feature/Student/StudentUpdateTest.php
+++ b/tests/Feature/Student/StudentUpdateTest.php
@@ -68,7 +68,7 @@ class StudentUpdateTest extends TestCase
             'github' => 'http://www.github.com/johnnydoe',
         ];
 
-        $response = $this->withHeaders(['Accept' => 'application/json'])->put('api/v1/students/'.$user->student->id, $data);
+        $response = $this->withHeaders(['Accept' => 'application/json'])->put('api/v1/students/' . $user->student->id, $data);
 
         $user = $user->fresh();
         $student = $user->student->fresh();

--- a/tests/Unit/Service/ResumeUpdateServiceTest.php
+++ b/tests/Unit/Service/ResumeUpdateServiceTest.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Service;
+
+use App\Models\Resume;
+use App\Models\Student;
+use App\Models\User;
+use App\Service\Resume\ResumeUpdateService;
+use Database\Factories\UserFactory;
+use Tests\TestCase;
+
+class ResumeUpdateServiceTest extends TestCase
+{
+    const A_SUBTITLE = 'a subtitle';
+    const HTTPS_A_LINKEDIN_URL = 'https://a-linkedin.url';
+    const HTTPS_A_GITHUB_URL = 'https://a-github.url';
+    const A_SPECIALIZATION = 'Frontend';
+
+    public function setUp(): void
+    {
+        parent::setUp();
+        $this->resumeUpdateService = new ResumeUpdateService();
+    }
+
+    public function tearDown(): void
+    {
+        $this->artisan('migrate:fresh');
+        parent::tearDown();
+    }
+
+    public function testCanInstantiate(): void
+    {
+        self::assertInstanceOf(ResumeUpdateService::class, $this->resumeUpdateService);
+    }
+
+    public function testCanUpdateAnExistingModel(): void
+    {
+        $userFactory = new UserFactory();
+        $definition = $userFactory->definition();
+        $user = new User($definition);
+        $user->save();
+
+        $student = new Student();
+        $student->setUniqueIds();
+        $student->user_id = $user->id;
+        $student->subtitle = '';
+        $student->save();
+
+        $resume = new Resume();
+        $resume->student_id = $student->id;
+        $resume->subtitle = '';
+        $resume->save();
+
+        $this->resumeUpdateService->execute(
+            $resume->getAttributeValue('id'),
+            self::A_SUBTITLE,
+            self::HTTPS_A_LINKEDIN_URL,
+            self::HTTPS_A_GITHUB_URL,
+            self::A_SPECIALIZATION
+        );
+
+        $actualResume = Resume::find($resume->id);
+
+        self::assertEquals(self::A_SUBTITLE, $actualResume->subtitle);
+        self::assertEquals(self::HTTPS_A_LINKEDIN_URL, $actualResume->linkedin_url);
+        self::assertEquals(self::HTTPS_A_GITHUB_URL, $actualResume->github_url);
+        self::assertEquals(self::A_SPECIALIZATION, $actualResume->specialization);
+    }
+}

--- a/tests/Unit/Service/ResumeUpdateServiceTest.php
+++ b/tests/Unit/Service/ResumeUpdateServiceTest.php
@@ -13,10 +13,10 @@ use Tests\TestCase;
 
 class ResumeUpdateServiceTest extends TestCase
 {
-    const A_SUBTITLE = 'a subtitle';
-    const HTTPS_A_LINKEDIN_URL = 'https://a-linkedin.url';
-    const HTTPS_A_GITHUB_URL = 'https://a-github.url';
-    const A_SPECIALIZATION = 'Frontend';
+    public const A_SUBTITLE = 'a subtitle';
+    public const HTTPS_A_LINKEDIN_URL = 'https://a-linkedin.url';
+    public const HTTPS_A_GITHUB_URL = 'https://a-github.url';
+    public const A_SPECIALIZATION = 'Frontend';
 
     public function setUp(): void
     {


### PR DESCRIPTION
En esta rama:

- Se extrae la lógica de update resume a un servicio ResumeUpdateService, que encapsula la lógica.
- Se simplifica lo que hace el modelo Resume (realmente no es necesario hacer tantas cosas en el modelo, todavía).
- Deja visible el hecho de que asignar y desasignar un tag al Resume deberian ser dos endpoints a parte.
- Simplifica el uso del  controlador (importa el servicio por dependencia y lo usa dentro eliminando cierta lógica innecesaria)

Veréis que en el caso del servicio SI que se usan nulls. Ésto es debido a que en éste caso el estado null hace referencia a una propiedad que no está llegando al método update, pero que tampoco queremos actualizar con un string vacío ('').