### PR TITLE
[BE]Fix/#108/Docs/Delete-servers-no-longer-used

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -17,6 +17,8 @@ jobs:
           sshpass -p ${{ secrets.SSH_PASSWORD }} ssh -o StrictHostKeyChecking=no ${{ secrets.SSH_USER }}@${{ secrets.SSH_HOST }} "cd /var/www/html/ita-profiles-backend && php artisan l5-swagger:generate"
           sshpass -p ${{ secrets.SSH_PASSWORD }} ssh -o StrictHostKeyChecking=no ${{ secrets.SSH_USER }}@${{ secrets.SSH_HOST }} "cd /var/www/html/ita-profiles-backend && php artisan migrate:fresh"
           sshpass -p ${{ secrets.SSH_PASSWORD }} ssh -o StrictHostKeyChecking=no ${{ secrets.SSH_USER }}@${{ secrets.SSH_HOST }} "cd /var/www/html/ita-profiles-backend && php artisan db:seed"
+          sshpass -p ${{ secrets.SSH_PASSWORD }} ssh -o StrictHostKeyChecking=no ${{ secrets.SSH_USER }}@${{ secrets.SSH_HOST }} "cd /var/www/html/ita-profiles-backend && echo \"L5_SWAGGER_CONST_HOST=https://itaperfils.eurecatacademy.org\" >> .env"
+          sshpass -p ${{ secrets.SSH_PASSWORD }} ssh -o StrictHostKeyChecking=no ${{ secrets.SSH_USER }}@${{ secrets.SSH_HOST }} "cd /var/www/html/ita-profiles-backend && echo \"API_VERSION=/api/v1/\" >> .env"
 
         env:
           SSH_PASSWORD: ${{ secrets.SSH_PASSWORD }}

--- a/app/Annotations/OpenApi/AnnotationsInfo.php
+++ b/app/Annotations/OpenApi/AnnotationsInfo.php
@@ -15,21 +15,6 @@ namespace App\Annotations\OpenApi;
  * )
  *   @OA\Server(
  *     url= L5_SWAGGER_CONST_HOST
- *   )
- *   @OA\Server(
- *     url="http://127.0.0.1:8000/api/v1"
- *   )
- *   @OA\Server(
- *     url= L5_SWAGGER_CONST_HOST
- *   )
- *   @OA\Server(
- *     url="http://127.0.0.1:8000/api/v1"
- *   )
- *   @OA\Server(
- *     url="https://itaperfils.eurecatacademy.org"
- *   )
- *   @OA\Server(
- *     url="https://itaperfils.eurecatacademy.org/api/v1"
- *   )
+ *       )
  */
 class AnnotationsInfo {}

--- a/config/l5-swagger.php
+++ b/config/l5-swagger.php
@@ -294,7 +294,7 @@ return [
          * Constants which can be used in annotations
          */
         'constants' => [
-            'L5_SWAGGER_CONST_HOST' => env('L5_SWAGGER_CONST_HOST', 'http://127.0.0.1:8000/api/v1'),
+            'L5_SWAGGER_CONST_HOST' => env('L5_SWAGGER_CONST_HOST', 'http://127.0.0.1:8000') . env('API_VERSION', '/api/v1'),
         ],
     ],
 ];


### PR DESCRIPTION
# Description
To resolve #108 we suggest the following changes:
## `app/Annotations/OpenApi/AnnotationsInfo.php`
We've deleted the servers that are no longer used, leaving just one which uses the Swagger constant set in `config/l5-swagger.php` file.
## `config/l5-swagger.php`
At Line 297 we've set the L5_SWAGGER_CONST_HOST to follow the value set in the `.env` file.
The `.env()` function takes the value from the `.env` file, or, if that constant is not set, takes the second parameter as a default.
Later, we concatenate the required end of the URL: `/api/v1`
### Why this?
We think that the following workflow can occur:
- A L5_SWAGGER_CONST_HOST constant is set in production `.env` file, allowing to show its own URL when in production.
- A L5_SWAGGER_CONST_HOST constant is set in local `.env` file. 
   - Not all the `.env` files have this constant set, but, when they have it, usually is set for "localhost".
- A L5_SWAGGER_CONST_HOST constant is not set anywhere.
   - This is the case when the default value comes into action.
---
[Related information](https://panjeh.medium.com/laravel-app-env-local-app-env-production-difference-aa9662ac81d0)