### PR TITLE
Fix/strict_types statement

### DIFF
--- a/database/migrations/2024_04_09_093348_add_modality_to_resumes.php
+++ b/database/migrations/2024_04_09_093348_add_modality_to_resumes.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strinc_types=1);
+declare(strict_types=1);
 
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;


### PR DESCRIPTION
This PR resolves an error in the strict_types declaration in the add_modality_to_resumes migration file.